### PR TITLE
Dropping compiler flag

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,9 @@ if [[ ${target_platform} =~ .*osx.* ]]; then
   sed -i 's/ -unroll//' ${SRC_DIR}/build/linux/Makefile_elmfire
 fi
 
+# patch the makefile to test compiler flags
+sed -i 's/-O3 -unroll -frecord-marker=4 -ffree-line-length-none -cpp -march=native -ffpe-summary=none/-O3 -unroll -frecord-marker=4 -ffree-line-length-none -cpp -ffpe-summary=none/' ${SRC_DIR}/build/linux/Makefile_elmfire
+
 cd build/linux && ./make_gnu.sh
 cp bin/elmfire_$ELMFIRE_VERSION $PREFIX/bin/elmfire
 cp bin/elmfire_debug_$ELMFIRE_VERSION $PREFIX/bin/elmfire_debug

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9b92cbea62f8d5a6b4e65fa0d9f6cdb4fbd8baf5a38d5e855d5bb0e663431217
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not linux]
   script_env:
     - ELMFIRE_VERSION={{ version }}


### PR DESCRIPTION
`-march=native` is causing SIGILLs, dropping it from the gfortran compiler flags.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
